### PR TITLE
Remove WCJS_TARGET option

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = require((process.env.WCJS_TARGET || './bin') + "/WebChimera.js.node");
+module.exports = require('./bin/WebChimera.js.node');

--- a/install.js
+++ b/install.js
@@ -5,7 +5,6 @@ var needle = require('needle');
 var _ = require('lodash');
 var downloader = require('./lib/downloader');
 var findProjectRoot = require('find-project-root');
-var mkdirp = require('mkdirp');
 var parsePath = require('parse-filepath');
 
 
@@ -73,15 +72,18 @@ function getWCJS(data) {
 
                 console.log('Acquiring: ', candidate.name);
                 
+                var dir = './bin';
                 try {
-                    stats = fs.lstatSync(data.dir);
+                    stats = fs.lstatSync(dir);
                     if (stats.isDirectory()) {
-                        fs.removeSync(data.dir);
+                        fs.removeSync(dir);
                     }
                 }
-                catch (e) { }
+                catch (e) { 
+                    fs.mkdir(dir);
+                }
                 
-                downloader.downloadAndUnpack(data.dir, candidate.browser_download_url)
+                downloader.downloadAndUnpack(dir, candidate.browser_download_url)
                     .then(function() {
                         resolve(data)
                     });
@@ -109,8 +111,7 @@ function parseEnv() {
         var version = process.env.WCJS_VERSION || inf.version || 'latest';
         var runtime = process.env.WCJS_RUNTIME || inf.runtime || 'electron';
         var runtimeVersion = process.env.WCJS_RUNTIME_VERSION || inf.runtime_version || 'latest';
-
-        mkdirp.sync(targetDir);
+        var targetDir = './bin';
 
         if (/^win/.test(platform))
             platform = 'win';
@@ -134,7 +135,6 @@ function parseEnv() {
                 arch: arch,
                 platform: platform
             },
-            dir: './bin',
             version: version
         });
     });

--- a/install.js
+++ b/install.js
@@ -1,4 +1,4 @@
-var fs = require('fs');
+var fs = require('fs-extra');
 var path = require('path');
 var Promise = require('bluebird');
 var needle = require('needle');
@@ -72,7 +72,15 @@ function getWCJS(data) {
                 }
 
                 console.log('Acquiring: ', candidate.name);
-
+                
+                try {
+                    stats = fs.lstatSync(data.dir);
+                    if (stats.isDirectory()) {
+                        fs.removeSync(data.dir);
+                    }
+                }
+                catch (e) { }
+                
                 downloader.downloadAndUnpack(data.dir, candidate.browser_download_url)
                     .then(function() {
                         resolve(data)
@@ -101,7 +109,6 @@ function parseEnv() {
         var version = process.env.WCJS_VERSION || inf.version || 'latest';
         var runtime = process.env.WCJS_RUNTIME || inf.runtime || 'electron';
         var runtimeVersion = process.env.WCJS_RUNTIME_VERSION || inf.runtime_version || 'latest';
-        var targetDir = process.env.WCJS_TARGET || inf.dir || './bin';
 
         mkdirp.sync(targetDir);
 
@@ -115,7 +122,7 @@ function parseEnv() {
             }
 
         console.log('Fetching WebChimera prebuilt for', capitalizeFirstLetter(runtime) + ':', '\nWebChimera version:', version, 
-            '\n' + capitalizeFirstLetter(runtime) + ' version:', runtimeVersion, '\nPlatform:', platform, '\nArch:', arch, '\nTarget dir:', path.resolve(targetDir));
+            '\n' + capitalizeFirstLetter(runtime) + ' version:', runtimeVersion, '\nPlatform:', platform, '\nArch:', arch);
 
         if (!(supported.runtimes.indexOf(runtime) > -1) || !(supported.platforms.indexOf(platform) > -1) || !(supported.arch.indexOf(arch) > -1))
             return reject('Unsupported runtime/arch/platform');
@@ -127,7 +134,7 @@ function parseEnv() {
                 arch: arch,
                 platform: platform
             },
-            dir: path.resolve(targetDir),
+            dir: './bin',
             version: version
         });
     });

--- a/install.js
+++ b/install.js
@@ -156,6 +156,9 @@ function getJson(url) {
 parseEnv()
     .then(getWCJS)
     .then(function() {
+        // Hack: RSAtom's release includes a broken symlink that doesn't seem to be needed anyway
+        // Keeping it will break Electron builder - we remove it until RSAtom fixes the issue
+        fs.unlink('./bin/lib/vlc/lib/liblzma.5.dylib');
         console.log('WebChimera with VLC Libs downloaded');
     })
     .catch(function(e) {

--- a/install.js
+++ b/install.js
@@ -115,7 +115,7 @@ function parseEnv() {
             }
 
         console.log('Fetching WebChimera prebuilt for', capitalizeFirstLetter(runtime) + ':', '\nWebChimera version:', version, 
-            '\n' + capitalizeFirstLetter(runtime) + ' version:', runtimeVersion, '\nPlatform:', platform, '\nArch:', arch, '\nTarget dir:', targetDir);
+            '\n' + capitalizeFirstLetter(runtime) + ' version:', runtimeVersion, '\nPlatform:', platform, '\nArch:', arch, '\nTarget dir:', path.resolve(targetDir));
 
         if (!(supported.runtimes.indexOf(runtime) > -1) || !(supported.platforms.indexOf(platform) > -1) || !(supported.arch.indexOf(arch) > -1))
             return reject('Unsupported runtime/arch/platform');
@@ -127,7 +127,7 @@ function parseEnv() {
                 arch: arch,
                 platform: platform
             },
-            dir: targetDir,
+            dir: path.resolve(targetDir),
             version: version
         });
     });

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "bluebird": "^2.10.0",
     "decompress-zip": "^0.2.0",
     "find-project-root": "^1.1.1",
+    "fs-extra": "^0.30.0",
     "graceful-ncp": "^2.0.0",
     "gunzip-maybe": "^1.2.1",
     "lodash": "^3.10.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "graceful-ncp": "^2.0.0",
     "gunzip-maybe": "^1.2.1",
     "lodash": "^3.10.1",
-    "mkdirp": "^0.5.1",
     "needle": "^0.10.0",
     "parse-filepath": "^0.6.3",
     "progress": "^1.1.8",


### PR DESCRIPTION
This option doesn't make much sense to me: it is the module's responsibility to know where to install stuff, and the developer shouldn't be able to tinker with where the files are installed.

This also fixes an issue where updating the module would duplicate the files due to the current implementation of the `stripRootFolder` function in `downloader.js`.
